### PR TITLE
Pyproject pyinstaller fix & Updater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ mypy = "^1.11.2"
 types-beautifulsoup4 = "^4.12.0.20240907"
 types-regex = "^2024.9.11.20240912"
 types-requests = "^2.32.0.20240914"
+pyinstaller = "^6.10.0"
+poetry-plugin-up = "^0.7.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Added pyinstaller so it installs in the venv and [poetry-plugin-up](https://github.com/MousaZeidBaker/poetry-plugin-up) which can be used to update all requirements in pyproject.toml to the latest compatible versions.
To update: `poetry up --latest`