### PR TITLE
tests: pytest test discovery errors for workspace

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import TypeAliasType, get_args
 import pytest
 
 import CLASSIC_Main
+from ClassicLib import YamlSettingsCache
 
 RUNTIME_FILES = (
     "CLASSIC Settings.yaml",
@@ -116,7 +117,7 @@ def _move_user_files() -> Generator[None]:
 
 
 @pytest.fixture(scope="session")
-def yaml_cache() -> CLASSIC_Main.YamlSettingsCache:
+def yaml_cache() -> YamlSettingsCache.YamlSettingsCache:
     """Initialize CLASSIC_Main's YAML Cache.
 
     This is required for any test that entails calls to:
@@ -124,7 +125,7 @@ def yaml_cache() -> CLASSIC_Main.YamlSettingsCache:
     - `get_setting()`
     - `classic_settings()`
     """
-    CLASSIC_Main.yaml_cache = CLASSIC_Main.YamlSettingsCache()
+    CLASSIC_Main.yaml_cache = YamlSettingsCache.YamlSettingsCache()
     assert isinstance(CLASSIC_Main.yaml_cache.cache, dict), "cache dict not created"
     assert isinstance(CLASSIC_Main.yaml_cache.file_mod_times, dict), "file_mod_times dict not created"
     return CLASSIC_Main.yaml_cache

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 import CLASSIC_Main
+from ClassicLib import YamlSettingsCache
 from tests.conftest import MOCK_YAML, MockYAML
 
 TEST_YAML_TEXT = """Section 1:
@@ -167,7 +168,7 @@ def test_remove_readonly_4() -> None:
 
 
 @pytest.fixture(scope="module")
-def test_load_yaml(test_file_yaml: Path, yaml_cache: CLASSIC_Main.YamlSettingsCache) -> CLASSIC_Main.YamlSettingsCache:
+def test_load_yaml(test_file_yaml: Path, yaml_cache: YamlSettingsCache.YamlSettingsCache) -> YamlSettingsCache.YamlSettingsCache:
     """Test CLASSIC_Main's `YamlSettingsCache`.`load_yaml()`."""
     fake_path = Path("Non-existant file")
     loaded_data_1 = yaml_cache.load_yaml(fake_path)
@@ -182,7 +183,7 @@ def test_load_yaml(test_file_yaml: Path, yaml_cache: CLASSIC_Main.YamlSettingsCa
 
 
 @pytest.mark.usefixtures("test_file_yaml")
-def test_YamlSettingsCache_get_setting(test_load_yaml: CLASSIC_Main.YamlSettingsCache) -> None:
+def test_YamlSettingsCache_get_setting(test_load_yaml: YamlSettingsCache.YamlSettingsCache) -> None:
     """Test CLASSIC_Main's `YamlSettingsCache`.`get_setting()`."""
     game = test_load_yaml.get_setting(CLASSIC_Main.YAML.TEST, "Section 1.Game Name")
     assert isinstance(game, str), "Section 1.Game Name should be a string"
@@ -284,9 +285,9 @@ def test_YamlSettingsCache_get_setting(test_load_yaml: CLASSIC_Main.YamlSettings
 
 
 @pytest.mark.usefixtures("test_file_yaml")
-def test_yaml_settings(test_load_yaml: CLASSIC_Main.YamlSettingsCache) -> None:
+def test_yaml_settings(test_load_yaml: YamlSettingsCache.YamlSettingsCache) -> None:
     """Test CLASSIC_Main's `yaml_settings()`."""
-    assert isinstance(test_load_yaml, CLASSIC_Main.YamlSettingsCache), "yaml cache should be initialized"
+    assert isinstance(test_load_yaml, YamlSettingsCache.YamlSettingsCache), "yaml cache should be initialized"
     game = CLASSIC_Main.yaml_settings(CLASSIC_Main.YAML.TEST, "Section 1.Game Name")
     assert isinstance(game, str), "Section 1.Game Name should be a string"
     assert game == "Elder Scrolls VI", "Section 1.Game Name should equal 'Elder Scrolls VI'"


### PR DESCRIPTION
This change fixes pytest test discovery errors in order to use test explorer in vscode to run tests.  The test failures are a separate topic but at least now test explorer can be used.

Before this change:

```
2025-06-04 16:31:05.701 [info] Discover tests for workspace name: CLASSIC-Fallout4-eda - uri: c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda
2025-06-04 16:31:05.703 [warning] The cwd resolves to a different path, checking if it has a symbolic link somewhere in its path.
2025-06-04 16:31:05.705 [info] arg: --rootdir already exists in args, not adding.
2025-06-04 16:31:05.705 [info] Environment variables set for pytest discovery: PYTHONPATH=c:\Users\andre\.vscode\extensions\ms-python.python-2025.6.1-win32-x64\python_files, TEST_RUN_PIPE=\\.\pipe\python-test-discovery-d24df5395d390673380c
2025-06-04 16:31:05.804 [info] > ./.venv/Scripts/activate.bat && echo 'e8b39361-0157-4923-80e1-22d70d46dee6' && python ~/.vscode/extensions/ms-python.python-2025.6.1-win32-x64/python_files/printEnvVariables.py
2025-06-04 16:31:05.804 [info] shell: commandPrompt
2025-06-04 16:31:05.943 [info] > .\.venv\Scripts\python.exe -m pytest -p vscode_pytest --collect-only --rootdir=.
2025-06-04 16:31:05.943 [info] cwd: .
2025-06-04 16:31:11.799 [error] ImportError while loading conftest 'c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda\tests\conftest.py'.

2025-06-04 16:31:11.890 [error] tests\conftest.py:119: in <module>
    def yaml_cache() -> CLASSIC_Main.YamlSettingsCache:
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'CLASSIC_Main' has no attribute 'YamlSettingsCache'

2025-06-04 16:31:11.984 [error] Subprocess exited unsuccessfully with exit code 4 and signal null on workspace c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda.
2025-06-04 16:31:11.984 [error] Subprocess exited unsuccessfully with exit code 4 and signal null on workspace c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda. Creating and sending error discovery payload
2025-06-04 16:31:11.984 [error] pytest test discovery error for workspace:  c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda 
  
 The python test process was terminated before it could exit on its own, the process errored with: Code: 4, Signal: null for workspace c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda
```

After this change:

```
2025-06-04 16:33:54.336 [info] Discover tests for workspace name: CLASSIC-Fallout4-eda - uri: c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda\tests\test_main.py
2025-06-04 16:33:54.338 [warning] The cwd resolves to a different path, checking if it has a symbolic link somewhere in its path.
2025-06-04 16:33:54.339 [info] arg: --rootdir already exists in args, not adding.
2025-06-04 16:33:54.339 [info] Environment variables set for pytest discovery: PYTHONPATH=c:\Users\andre\.vscode\extensions\ms-python.python-2025.6.1-win32-x64\python_files, TEST_RUN_PIPE=\\.\pipe\python-test-discovery-07943911f17d97d54773
2025-06-04 16:33:54.346 [info] > .\.venv\Scripts\python.exe -m pytest -p vscode_pytest --collect-only --rootdir=.
2025-06-04 16:33:54.346 [info] cwd: .
2025-06-04 16:34:00.300 [info] ============================= test session starts =============================
platform win32 -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
rootdir: c:\Users\andre\Documents\GitHub\achekery\CLASSIC-Fallout4-eda
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-0.24.0, cov-5.0.0
asyncio: mode=Mode.STRICT, default_loop_scope=None

2025-06-04 16:34:01.401 [info] collected 22 items


2025-06-04 16:34:01.402 [info] <Dir CLASSIC-Fallout4-eda>
  <Package tests>
    <Module test_main.py>
      <Function test_mock_yaml>
      <Function test_remove_readonly_1>
      <Function test_remove_readonly_2>
      <Function test_remove_readonly_3>
      <Function test_remove_readonly_4>
      <Function test_YamlSettingsCache_get_setting>
      <Function test_yaml_settings>
      <Function test_classic_generate_files>
      <Function test_classic_settings>
      <Function test_configure_logging>
      <Function test_classic_data_extract>
      <Function test_open_file_with_encoding>
      <Coroutine test_classic_update_check>
      <Function test_docs_path_find>
      <Function test_game_path_find_1>
      <Function test_game_path_find_2>
      <Function test_game_path_find_3>
    <Module test_scan_logs.py>
      <Function test_pastebin_fetch>
      <Function test_get_entry>
      <Function test_crashlogs_get_files>
      <Function test_crashlogs_reformat>
      <Function test_crashlogs_scan>

2025-06-04 16:34:02.686 [info] 

---------- coverage: platform win32, python 3.12.10-final-0 ----------
Name                                     Stmts   Miss  Cover
------------------------------------------------------------
CLASSIC_Interface.py                       716    716     0%
CLASSIC_Main.py                            158    129    18%
CLASSIC_ScanGame.py                        276    251     9%
CLASSIC_ScanLogs.py                        585    526    10%
ClassicLib\Constants.py                     36      0   100%
ClassicLib\DocsPath.py                     159    127    20%
ClassicLib\GamePath.py                      89     79    11%
ClassicLib\GlobalRegistry.py                48     18    62%
ClassicLib\GuiComponents.py                 24     24     0%
ClassicLib\Interface\Audio.py               51     51     0%
ClassicLib\Interface\Papyrus.py             55     55     0%
ClassicLib\Interface\Pastebin.py            29     29     0%
ClassicLib\Interface\PathDialog.py          29     29     0%
ClassicLib\Interface\StyleSheets.py          1      1     0%
ClassicLib\Interface\__init__.py             0      0   100%
ClassicLib\Logger.py                         2      0   100%
ClassicLib\Meta.py                           7      0   100%
ClassicLib\PapyrusLog.py                    27     27     0%
ClassicLib\ScanGame\CheckCrashgen.py        76     56    26%
ClassicLib\ScanGame\CheckXsePlugins.py      54     35    35%
ClassicLib\ScanGame\Config.py              173    134    23%
ClassicLib\ScanGame\ScanModInis.py          57     42    26%
ClassicLib\ScanGame\WryeCheck.py            53     43    19%
ClassicLib\ScanGame\__init__.py              0      0   100%
ClassicLib\ScanLog\DetectMods.py            43     43     0%
ClassicLib\ScanLog\ScanLogInfo.py           93     51    45%
ClassicLib\ScanLog\Util.py                  79     62    22%
ClassicLib\ScanLog\__init__.py               0      0   100%
ClassicLib\Update.py                       220    220     0%
ClassicLib\Util.py                         148    113    24%
ClassicLib\XseCheck.py                     119    100    16%
ClassicLib\YamlSettingsCache.py            113     90    20%
ClassicLib\__init__.py                       0      0   100%
tests\__init__.py                            0      0   100%
tests\conftest.py                           82     59    28%
tests\test_main.py                         352    293    17%
tests\test_scan_logs.py                     70     58    17%
------------------------------------------------------------
TOTAL                                     4024   3461    14%
Coverage LCOV written to file lcov.info


2025-06-04 16:34:02.688 [info] ========================= 22 tests collected in 2.40s =========================
```