### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,3 +231,45 @@ GitHub Actions on `windows-latest` with parallel jobs:
 4. **Rust Tests** (independent, parallel with Python pipeline)
 5. **Node.js Bindings** (Bun): build NAPI-RS binary + run Bun tests (independent)
 6. **Benchmarks** (`benchmarks.yml`): separate workflow for performance tracking
+
+## Cursor Cloud specific instructions
+
+### Platform notes
+
+This project's CI runs exclusively on `windows-latest`. On the Linux Cloud Agent VM:
+
+- **`classic-path-core`** has Linux-specific compilation fixes applied (unused import, `.map_err()` type mismatch, dead code warnings). These are minimal `cfg_attr`/`allow` changes.
+- **`classic-scangame-core`** and **`classic-resource-core`** depend on `ba2` -> `directxtex` (DirectX), which cannot build on Linux. Exclude them: `--exclude classic-scangame-core --exclude classic-resource-core`.
+- **`classic-tui`** (Rust TUI) requires `wayland-client` dev headers (`libwayland-dev`). Not installed by default; the Python TUI (`ClassicLib.TUI`) is the simpler alternative.
+- **C++ targets** (`classic-cli`, `classic-gui`) require MSVC and cannot build on Linux.
+
+### Running services
+
+- **PySide6 GUI**: Requires `QT_QPA_PLATFORM=offscreen` and `libegl1 libopengl0` system packages. Launch with minimal registry init (see setup session) since `SetupCoordinator.initialize_application()` prompts for game paths interactively on Linux (no Fallout 4/Skyrim installed).
+- **CLI scanner** (`CLASSIC_ScanLogs.py`): Has pre-existing sync-in-async-context bugs that prevent execution (`yaml_settings()` called from async context in `executor.py` and `util_legacy.py`). These are code issues, not environment issues.
+
+### Quick reference
+
+Standard commands from AGENTS.md/CLAUDE.md apply. Key Linux-specific adjustments:
+
+| Task | Command |
+|---|---|
+| Python deps | `uv sync --all-extras` |
+| Python lint | `uv run ruff check .` and `uv run ruff format --check .` |
+| Python tests | `QT_QPA_PLATFORM=offscreen uv run pytest -m unit --skip-slow --skip-network --skip-performance --skip-stress --no-cov --ignore=tests/integration/test_rust_scanners_integration.py --ignore=tests/integration/test_scangame_factory_integration.py` |
+| Rust build | `cargo build --workspace --exclude classic-scangame-core --exclude classic-resource-core --exclude classic-tui --exclude classic-node --exclude classic-cpp-bridge --manifest-path ClassicLib-rs/Cargo.toml` (excludes Windows/wayland-dependent crates) |
+| Rust lint | `cargo clippy -p <crate> --all-targets --all-features --manifest-path ClassicLib-rs/Cargo.toml -- -D warnings` |
+| Rust tests | `cargo test -p <crate> --manifest-path ClassicLib-rs/Cargo.toml` (test individual core crates; PyO3 binding crate tests fail to link without Python shared lib) |
+| Build PyO3 bindings | From each binding crate dir: `maturin build --release --out dist` then `uv pip install dist/*.whl --force-reinstall` (the `.venv/bin/maturin` path must be used) |
+
+### PyO3 binding installation
+
+The `rebuild_rust.ps1` script is Windows-only. On Linux, build each binding crate individually:
+
+```bash
+cd ClassicLib-rs/python-bindings/<crate-name>  # or foundation/<crate-name>
+/workspace/.venv/bin/maturin build --release --out dist
+uv pip install dist/*.whl --force-reinstall
+```
+
+There are 18 binding crates total (1 foundation + 17 python-bindings). Crates depending on `classic-scangame-core` or `classic-resource-core` (`classic-scangame-py`, `classic-resource-py`) cannot build on Linux.

--- a/ClassicLib-rs/business-logic/classic-path-core/src/docs_path.rs
+++ b/ClassicLib-rs/business-logic/classic-path-core/src/docs_path.rs
@@ -188,7 +188,7 @@ impl DocsPathFinder {
     fn find_docs_path_linux(&self) -> DocsPathResult<PathBuf> {
         use crate::platform::linux::get_home_directory;
 
-        let home = get_home_directory().map_err(|e| DocsPathError::PathError(e))?;
+        let home = get_home_directory()?;
 
         // For Linux, use Wine's compatibility folder structure
         let docs_path = home.join(".local/share").join(&self.relative_path);

--- a/ClassicLib-rs/business-logic/classic-path-core/src/game_path.rs
+++ b/ClassicLib-rs/business-logic/classic-path-core/src/game_path.rs
@@ -57,6 +57,7 @@ pub struct GamePathFinder {
     xse_loader: Option<String>,
 
     /// Game name for registry queries (e.g., "Fallout4")
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     game_name: String,
 
     /// Whether this is a VR version of the game

--- a/ClassicLib-rs/business-logic/classic-path-core/src/platform/linux.rs
+++ b/ClassicLib-rs/business-logic/classic-path-core/src/platform/linux.rs
@@ -167,6 +167,7 @@ fn extract_vdf_value(line: &str) -> Option<String> {
 /// let docs_path = construct_proton_docs_path(&library, 377160, "My Games/Fallout4");
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[allow(dead_code)]
 pub fn construct_proton_docs_path(
     library_path: &PathBuf,
     game_steam_id: u32,

--- a/ClassicLib-rs/business-logic/classic-path-core/src/platform/mod.rs
+++ b/ClassicLib-rs/business-logic/classic-path-core/src/platform/mod.rs
@@ -7,7 +7,9 @@
 //! The public API uses conditional compilation to expose the appropriate
 //! platform implementation.
 
-use crate::error::{DocsPathError, DocsPathResult};
+use crate::error::DocsPathResult;
+#[cfg(target_os = "windows")]
+use crate::error::DocsPathError;
 use std::path::PathBuf;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Fix Linux compilation errors and dead-code warnings in `classic-path-core` to enable development environment setup on Linux.

---
<p><a href="https://cursor.com/agents/bc-1adf0b79-fb43-45fe-8fb3-b25e1f6f7121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1adf0b79-fb43-45fe-8fb3-b25e1f6f7121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions plus small compile/lint fixes guarded by `cfg`/`allow` attributes; behavior changes are minimal and localized to Linux path detection error mapping.
> 
> **Overview**
> Improves Linux developer ergonomics by adding **Cursor Cloud/Linux setup guidance** to `AGENTS.md`, including which Rust crates to exclude on Linux, headless PySide6 test/run flags, and how to build/install PyO3 bindings without the Windows-only `rebuild_rust.ps1`.
> 
> Fixes `classic-path-core` non-Windows build issues by removing an unnecessary `.map_err()` in Linux docs-path detection, scoping `DocsPathError` imports to Windows-only in `platform/mod.rs`, and silencing dead-code warnings with minimal `allow`/`cfg_attr` annotations (e.g., `game_name`, `construct_proton_docs_path`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d384fecdc5461fafb1fa79282daed40d648962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->