### PR TITLE
Linux compilation errors

### DIFF
--- a/ClassicLib-rs/business-logic/classic-resource-core/Cargo.toml
+++ b/ClassicLib-rs/business-logic/classic-resource-core/Cargo.toml
@@ -22,9 +22,6 @@ anyhow = { workspace = true }
 # File I/O
 walkdir = { workspace = true }
 
-# BA2 archive support
-ba2 = { workspace = true }
-
 # Serialization
 serde = { workspace = true, features = ["derive"] }
 

--- a/ClassicLib-rs/business-logic/classic-scangame-core/Cargo.toml
+++ b/ClassicLib-rs/business-logic/classic-scangame-core/Cargo.toml
@@ -24,7 +24,6 @@ futures = { workspace = true }
 # File operations
 walkdir = { workspace = true }
 ddsfile = { workspace = true }
-ba2 = { workspace = true }
 
 # Configuration file processing
 sha2 = { workspace = true }
@@ -74,6 +73,9 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+ba2 = { workspace = true }
 
 [lints.rust]
 deprecated = "deny"

--- a/ClassicLib-rs/business-logic/classic-scangame-core/src/ba2.rs
+++ b/ClassicLib-rs/business-logic/classic-scangame-core/src/ba2.rs
@@ -14,12 +14,15 @@
 //! Uses the `ba2` crate (v3.0.1) for low-level archive parsing, with business logic
 //! for CLASSIC-specific validation rules and issue detection.
 
-use std::fs::File;
 use std::path::{Path, PathBuf};
 
+#[cfg(windows)]
 use ba2::fo4::{Archive, FileHeader};
+#[cfg(windows)]
 use ba2::{ByteSlice, Reader};
 use rayon::prelude::*;
+#[cfg(windows)]
+use std::fs::File;
 use thiserror::Error;
 
 /// Errors that can occur during BA2 scanning
@@ -40,6 +43,10 @@ pub enum BA2Error {
     /// File not found in archive
     #[error("File not found: {0}")]
     FileNotFound(String),
+
+    /// BA2 archive scanning is not available on this platform.
+    #[error("BA2 archive scanning is not supported on this platform")]
+    UnsupportedPlatform,
 }
 
 /// Result type for BA2 operations
@@ -153,6 +160,7 @@ impl BA2Scanner {
     /// }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(windows)]
     pub fn scan_archive(&self, path: &Path) -> Result<BA2Issues> {
         // Open archive with memory-mapped I/O
         let file = File::open(path)?;
@@ -195,6 +203,16 @@ impl BA2Scanner {
         Ok(issues)
     }
 
+    /// Scan a single BA2 archive and detect issues.
+    ///
+    /// On non-Windows platforms this returns `BA2Error::UnsupportedPlatform`.
+    #[cfg(not(windows))]
+    pub fn scan_archive(&self, _path: &Path) -> Result<BA2Issues> {
+        // Keep the same API surface cross-platform while making unsupported behavior explicit.
+        let _ = &self.xse_patterns;
+        Err(BA2Error::UnsupportedPlatform)
+    }
+
     /// Scan multiple archives in parallel
     ///
     /// Uses Rayon for parallel processing to maximize throughput.
@@ -227,6 +245,7 @@ impl BA2Scanner {
     }
 
     /// Scan a DX10 texture file and detect issues
+    #[cfg(windows)]
     fn scan_dx10_texture(
         &self,
         file_name: &str,
@@ -260,6 +279,7 @@ impl BA2Scanner {
     }
 
     /// Scan a GNRL general file and detect issues
+    #[cfg(windows)]
     fn scan_gnrl_file(
         &self,
         file_name: &str,
@@ -349,6 +369,8 @@ impl Default for BA2Scanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(windows))]
+    use std::path::Path;
 
     #[test]
     fn test_ba2_issues_default() {
@@ -378,5 +400,13 @@ mod tests {
 
         let custom_scanner = BA2Scanner::with_xse_patterns(vec!["f4se".to_string()]);
         assert_eq!(custom_scanner.xse_patterns.len(), 1);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_scan_archive_unsupported_platform() {
+        let scanner = BA2Scanner::new();
+        let result = scanner.scan_archive(Path::new("mod.ba2"));
+        assert!(matches!(result, Err(BA2Error::UnsupportedPlatform)));
     }
 }

--- a/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/Cargo.toml
+++ b/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/evildarkarchon/CLASSIC-Fallout4"
 crate-type = ["staticlib", "lib"]  # staticlib for C++ linking, lib for Rust tests
 
 [dependencies]
-# CXX FFI framework
-cxx = { workspace = true }
-
 # Markdown → HTML rendering
 pulldown-cmark = { workspace = true, features = ["html"] }
 
@@ -58,7 +55,11 @@ classic-update-core = { path = "../../business-logic/classic-update-core" }
 tempfile = { workspace = true }
 serial_test = "3.2"
 
-[build-dependencies]
+[target.'cfg(windows)'.dependencies]
+# CXX FFI framework
+cxx = { workspace = true }
+
+[target.'cfg(windows)'.build-dependencies]
 cxx-build = { workspace = true }
 
 [lints.rust]

--- a/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/build.rs
+++ b/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/build.rs
@@ -1,3 +1,4 @@
+#[cfg(windows)]
 fn main() {
     cxx_build::bridges([
         "src/types.rs",
@@ -19,5 +20,10 @@ fn main() {
     .std("c++17")
     .compile("classic-cpp-bridge");
 
+    println!("cargo:rerun-if-changed=src/");
+}
+
+#[cfg(not(windows))]
+fn main() {
     println!("cargo:rerun-if-changed=src/");
 }

--- a/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/src/lib.rs
+++ b/ClassicLib-rs/cpp-bindings/classic-cpp-bridge/src/lib.rs
@@ -45,18 +45,36 @@
 //! - [`message`] - Logging
 //! - [`perf`] - Performance monitoring
 
+#[cfg(windows)]
 pub mod config;
+#[cfg(windows)]
 pub mod database;
+#[cfg(windows)]
 pub mod files;
+#[cfg(windows)]
 pub mod game;
+#[cfg(windows)]
 pub mod markdown;
+#[cfg(windows)]
 pub mod message;
+#[cfg(windows)]
 pub mod path;
+#[cfg(windows)]
 pub mod perf;
+#[cfg(windows)]
 pub mod registry;
+#[cfg(windows)]
 pub mod runtime;
+#[cfg(windows)]
 pub mod scangame;
+#[cfg(windows)]
 pub mod scanner;
+#[cfg(windows)]
 pub mod types;
+#[cfg(windows)]
 pub mod update;
+#[cfg(windows)]
 pub mod yaml;
+
+#[cfg(not(windows))]
+pub const CPP_BRIDGE_UNAVAILABLE: &str = "classic-cpp-bridge is only available on Windows targets";

--- a/ClassicLib-rs/ui-applications/classic-tui/Cargo.toml
+++ b/ClassicLib-rs/ui-applications/classic-tui/Cargo.toml
@@ -36,8 +36,10 @@ yaml-rust2 = { workspace = true }
 
 open = "5"
 arboard = "3"
-rfd = "0.15"
 color-eyre = "0.6"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+rfd = "0.15"
 
 [lints.rust]
 deprecated = "deny"

--- a/ClassicLib-rs/ui-applications/classic-tui/src/event.rs
+++ b/ClassicLib-rs/ui-applications/classic-tui/src/event.rs
@@ -485,27 +485,37 @@ impl App {
     }
 
     fn open_folder_dialog_for_focus(&mut self) {
-        let initial = match self.main_focus {
-            MainFocus::StagingBrowse => self.staging_mods_input.value.trim(),
-            MainFocus::CustomBrowse => self.custom_scan_input.value.trim(),
-            _ => "",
-        };
-
-        let mut dialog = rfd::FileDialog::new();
-        if !initial.is_empty() {
-            dialog = dialog.set_directory(initial);
+        #[cfg(target_os = "linux")]
+        {
+            self.scan_status =
+                "Folder browser is unavailable on this Linux build. Enter the path manually."
+                    .to_string();
         }
 
-        if let Some(path) = dialog.pick_folder() {
-            let value = path.to_string_lossy().to_string();
-            match self.main_focus {
-                MainFocus::StagingBrowse => self.staging_mods_input.set_value(value),
-                MainFocus::CustomBrowse => self.custom_scan_input.set_value(value),
-                _ => {}
+        #[cfg(not(target_os = "linux"))]
+        {
+            let initial = match self.main_focus {
+                MainFocus::StagingBrowse => self.staging_mods_input.value.trim(),
+                MainFocus::CustomBrowse => self.custom_scan_input.value.trim(),
+                _ => "",
+            };
+
+            let mut dialog = rfd::FileDialog::new();
+            if !initial.is_empty() {
+                dialog = dialog.set_directory(initial);
             }
 
-            if let Err(error) = self.save_paths_from_inputs() {
-                self.scan_status = error;
+            if let Some(path) = dialog.pick_folder() {
+                let value = path.to_string_lossy().to_string();
+                match self.main_focus {
+                    MainFocus::StagingBrowse => self.staging_mods_input.set_value(value),
+                    MainFocus::CustomBrowse => self.custom_scan_input.set_value(value),
+                    _ => {}
+                }
+
+                if let Err(error) = self.save_paths_from_inputs() {
+                    self.scan_status = error;
+                }
             }
         }
     }


### PR DESCRIPTION
Enable full Rust workspace compilation on Linux by resolving platform-specific dependency issues.

This PR addresses compilation failures on Linux by:
-   Making `ba2` (and its `directxtex` dependency) Windows-only in `classic-scangame-core` with a Linux fallback.
-   Removing unused `ba2` from `classic-resource-core`.
-   Gating `rfd` (and its `wayland-sys` dependency) in `classic-tui` for Linux, providing a fallback for browse actions.
-   Making `cxx` and `cxx-build` Windows-only in `classic-cpp-bridge` with a Linux stub implementation.

---
<p><a href="https://cursor.com/agents/bc-320d3d46-3428-46be-b848-c23c27976310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-320d3d46-3428-46be-b848-c23c27976310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily conditional compilation and dependency gating to restore cross-platform builds; behavior changes are limited to disabling BA2 scanning and folder dialogs on non-Windows/Linux builds.
> 
> **Overview**
> Fixes Linux workspace compilation by gating Windows-only functionality behind `cfg(windows)` and providing explicit stubs/fallbacks on other platforms.
> 
> In `classic-scangame-core`, the `ba2` dependency and BA2 scanning implementation are Windows-only; non-Windows builds keep the same `BA2Scanner` API but `scan_archive` now returns `BA2Error::UnsupportedPlatform` (with a test covering this). In `classic-cpp-bridge`, `cxx`/`cxx-build` and bridge modules/build steps are Windows-only, with a non-Windows build script stub and a `CPP_BRIDGE_UNAVAILABLE` constant. In `classic-tui`, `rfd` is excluded on Linux and folder browsing now shows a status message on Linux instead of opening a dialog; `classic-resource-core` drops an unused `ba2` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97d199d3888a3450bf12c4fa52f44f0c0158c633. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->